### PR TITLE
Reduce placeholder false positives in secret-scanner

### DIFF
--- a/skills/secret-scanner/engine.py
+++ b/skills/secret-scanner/engine.py
@@ -29,7 +29,8 @@ MAX_LINE_LEN = 4096
 
 PLACEHOLDER_RE = re.compile(
     r"(?i)(example|sample|dummy|placeholder|your[_-]?key|xxx+|00000+|"
-    r"123456|changeme|redacted|test[_-]?key|fake|<[^>]+>|\$\{[^}]+\})"
+    r"123456|changeme|redacted|test[_-]?key|testvalue|donotuse|"
+    r"mykey|yourtoken|notreal|fake|<[^>]+>|\$\{[^}]+\})"
 )
 
 

--- a/skills/secret-scanner/tests/test_engine.py
+++ b/skills/secret-scanner/tests/test_engine.py
@@ -24,6 +24,8 @@ def test_entropy_random_is_high():
 
 def test_looks_like_secret_rejects_placeholder():
     assert not engine.looks_like_secret("your_api_key_here", 3.5)
+    assert not engine.looks_like_secret("yourtoken-abc123", 3.5)
+    assert not engine.looks_like_secret("notreal_value", 3.5)
 
 
 def test_looks_like_secret_rejects_short():


### PR DESCRIPTION
## Summary
- Expand `PLACEHOLDER_RE` in `skills/secret-scanner/engine.py` to include additional common placeholders (`notreal`, `donotuse`, `testvalue`, `yourtoken`, `mykey`).
- Add assertions in `skills/secret-scanner/tests/test_engine.py` to ensure the new placeholders are rejected by `looks_like_secret`.

Closes #18.

## Validation
- `python -m pytest skills/secret-scanner/tests/test_engine.py -q` (in isolated venv): `24 passed`
