### PR TITLE
Add common weak JWT secrets to default wordlist

### DIFF
--- a/skills/jwt-inspector/inspector.py
+++ b/skills/jwt-inspector/inspector.py
@@ -131,6 +131,7 @@ DEFAULT_WEAK_SECRETS = [
     "secret", "password", "123456", "changeme", "admin", "jwt", "token",
     "secretkey", "supersecret", "key", "your-256-bit-secret", "test",
     "qwerty", "letmein", "default", "root", "private", "s3cr3t",
+    "password123", "secret123", "jwtsecret", "mysecret", "P@ssw0rd", "welcome",
 ]
 
 _HASH_BY_ALG = {"HS256": hashlib.sha256, "HS384": hashlib.sha384,

--- a/skills/jwt-inspector/tests/test_inspector.py
+++ b/skills/jwt-inspector/tests/test_inspector.py
@@ -78,6 +78,16 @@ def test_crack_weak_secret():
     assert any(i["id"] == "weak-secret" for i in result["issues"])
 
 
+@pytest.mark.parametrize("secret", ["password123", "P@ssw0rd", "welcome"])
+def test_crack_extended_weak_secret_candidates(secret):
+    token = inspector.sign_hs256({"alg": "HS256"},
+                                 {"sub": "1", "exp": int(time.time()) + 60},
+                                 secret)
+    result = inspector.inspect(token)
+    assert result["cracked_secret"] == secret
+    assert any(issue["id"] == "weak-secret" for issue in result["issues"])
+
+
 def test_strong_secret_not_cracked():
     token = inspector.sign_hs256(
         {"alg": "HS256"}, {"sub": "1", "exp": int(time.time()) + 60},


### PR DESCRIPTION
Closes #17.

## Summary
- Extend jwt-inspector `DEFAULT_WEAK_SECRETS` with commonly seen weak values requested in issue #17.
- Add regression tests to verify those new entries can crack HMAC-signed JWT tokens.

## Validation
- python -m pytest skills/jwt-inspector/tests/test_inspector.py -q (via isolated venv)
- Result: 17 passed
