### PR TITLE
feat: parse pyproject.toml dependencies

### DIFF
--- a/skills/dependency-check/checker.py
+++ b/skills/dependency-check/checker.py
@@ -87,21 +87,62 @@ class Dep:
     pinned: bool
 
 
+def _parse_dependency_token(text: str) -> tuple[str | None, str | None, bool] | None:
+    token = text.split(";", 1)[0].strip()
+    token = token.split("#", 1)[0].strip()
+    if not token:
+        return None
+    m = re.match(
+        r"^([A-Za-z0-9_.\-]+(?:\[[^\]]+\])?)\s*(==|>=|<=|~=|>|<|!=)?\s*([^\s;,]+)?",
+        token)
+    if not m:
+        return None
+    name = m.group(1).split("[", 1)[0].lower()
+    op, ver = m.group(2), m.group(3)
+    pinned = op == "==" and bool(ver)
+    version = ver if pinned or op else (ver if op and ver else None)
+    return name, version, pinned
+
+
 def parse_requirements(text: str) -> list[Dep]:
     deps: list[Dep] = []
     for line in text.splitlines():
         line = line.split("#", 1)[0].strip()
         if not line or line.startswith("-"):
             continue
-        m = re.match(r"^([A-Za-z0-9_.\-]+)\s*(==|>=|<=|~=|>|<|!=)?\s*([^\s;,]+)?",
-                     line)
-        if not m:
+        parsed = _parse_dependency_token(line)
+        if not parsed:
             continue
-        name = m.group(1).lower()
-        op, ver = m.group(2), m.group(3)
-        pinned = op == "==" and bool(ver)
-        deps.append(Dep("pypi", name, ver if pinned else (ver if op else None),
-                        line, pinned))
+        name, version, pinned = parsed
+        deps.append(Dep("pypi", name, version, line, pinned))
+    return deps
+
+
+def parse_pyproject_toml(text: str) -> list[Dep]:
+    try:
+        import tomllib
+    except Exception:
+        return []
+
+    try:
+        data = tomllib.loads(text)
+    except Exception:
+        return []
+
+    deps: list[Dep] = []
+    project = data.get("project") or {}
+    project_deps = project.get("dependencies") or []
+    if not isinstance(project_deps, list):
+        return []
+
+    for dep in project_deps:
+        if not isinstance(dep, str):
+            continue
+        parsed = _parse_dependency_token(dep)
+        if not parsed:
+            continue
+        name, version, pinned = parsed
+        deps.append(Dep("pypi", name, version, dep, pinned))
     return deps
 
 
@@ -190,6 +231,8 @@ def parse_file(path: str) -> list[Dep]:
     base = os.path.basename(path).lower()
     if base == "package.json":
         return parse_package_json(text)
+    if base == "pyproject.toml":
+        return parse_pyproject_toml(text)
     if base.endswith(".txt") or "requirements" in base:
         return parse_requirements(text)
     return parse_requirements(text)
@@ -199,7 +242,7 @@ def discover(path: str) -> list[str]:
     if os.path.isfile(path):
         return [path]
     found = []
-    for name in ("requirements.txt", "package.json"):
+    for name in ("requirements.txt", "package.json", "pyproject.toml"):
         candidate = os.path.join(path, name)
         if os.path.isfile(candidate):
             found.append(candidate)

--- a/skills/dependency-check/tests/test_checker.py
+++ b/skills/dependency-check/tests/test_checker.py
@@ -33,6 +33,30 @@ def test_parse_requirements_skips_blank_and_flags():
     assert {d.name for d in deps} == {"flask"}
 
 
+def test_parse_pyproject_toml_dependencies():
+    toml = """
+    [project]
+    dependencies = [
+      "flask==2.0.0",
+      "requests>=2.25",
+      "pandas; python_version < '3.11'",
+      "# ignored comment",
+    ]
+    """
+    deps = checker.parse_pyproject_toml(toml)
+    assert {d.name for d in deps} == {"flask", "requests", "pandas"}
+    flask = next(d for d in deps if d.name == "flask")
+    assert flask.pinned and flask.version == "2.0.0"
+    requests = next(d for d in deps if d.name == "requests")
+    assert not requests.pinned and requests.version == "2.25"
+    pandas = next(d for d in deps if d.name == "pandas")
+    assert not pandas.pinned and pandas.version is None
+
+
+def test_parse_pyproject_toml_invalid_returns_empty():
+    assert checker.parse_pyproject_toml("[not a valid toml") == []
+
+
 def test_parse_package_json():
     pkg = json.dumps({
         "dependencies": {"lodash": "4.17.20", "axios": "^0.21.0"},
@@ -88,6 +112,18 @@ def test_run_directory(tmp_path):
     result = checker.run(str(tmp_path))
     assert result["dependency_count"] == 1
     assert result["vulnerabilities"]
+
+
+def test_run_directory_with_pyproject_toml(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        """
+        [project]
+        dependencies = ["flask==0.12.2"]
+        """
+    )
+    result = checker.run(str(tmp_path))
+    assert result["dependency_count"] == 1
+    assert len(result["vulnerabilities"]) == 1
 
 
 def test_cli_exit_code_vuln(tmp_path):


### PR DESCRIPTION
## Summary
- Add `pyproject.toml` discovery to `dependency-check`.
- Parse `[project].dependencies` with stdlib `tomllib` and skip gracefully when TOML is unavailable or invalid.
- Keep existing dependency parsing behavior for requirements and package.json intact.
- Add focused tests for parsing and scanning a `pyproject.toml` fixture.

Closes #9

## Validation
- `python3 -m pytest skills/dependency-check/tests/test_checker.py -q` (run in isolated virtualenv): **19 passed**
- `npm run check` was attempted in this repository, but it runs a broader workspace test matrix and fails due unrelated environment/test dependency issues.
