### PR TITLE
feat(secret-scanner): add Mailgun and Postmark token rules

### DIFF
--- a/skills/secret-scanner/engine.py
+++ b/skills/secret-scanner/engine.py
@@ -84,6 +84,12 @@ RULES: list[Rule] = [
          _c(r"\b(npm_[A-Za-z0-9]{36})\b"), 1),
     Rule("pypi-token", "PyPI upload token", "critical",
          _c(r"\b(pypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{50,})\b"), 1),
+    Rule("mailgun-api-token", "Mailgun API token", "high",
+         _c(r"(?i)^(?=.*mailgun).*\b(key-[A-Fa-f0-9]{32})\b"), 1,
+         keywords=("mailgun",)),
+    Rule("postmark-api-token", "Postmark server token", "high",
+         _c(r"(?i)^(?=.*postmark).*\b(key-[A-Fa-f0-9]{32})\b"), 1,
+         keywords=("postmark",)),
     Rule("jwt", "JSON Web Token", "low",
          _c(r"\b(eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b"), 1),
     Rule("private-key", "Private key block", "critical",
@@ -104,6 +110,7 @@ NO_ENTROPY_RULES = {
     "anthropic-key", "openai-key", "slack-token", "slack-webhook",
     "aws-access-key-id", "google-api-key", "sendgrid-key", "twilio-key",
     "npm-token", "pypi-token", "basic-auth-url", "jwt",
+    "mailgun-api-token", "postmark-api-token",
 }
 
 

--- a/skills/secret-scanner/tests/test_engine.py
+++ b/skills/secret-scanner/tests/test_engine.py
@@ -41,11 +41,21 @@ def test_looks_like_secret_accepts_real():
     ("google-api-key", "AIza" + ("Bc" * 18)[:35]),
     ("stripe-secret", "sk_live_" + "a1B2c3D4e5F6g7H8i9J0k1L2"),
     ("anthropic-key", "sk-ant-" + "a1B2c3D4e5F6g7H8i9J0k1L2"),
+    ("mailgun-api-token", "mailgun_token = 'key-" + ("a1b2" * 8) + "'"),
+    ("postmark-api-token", "postmark_server_key = 'key-" + ("1a2b" * 8) + "'"),
 ])
 def test_rule_detects(rule_id, sample):
-    findings = engine.scan_text(f"key = '{sample}'", "f.py", 3.5, True)
+    findings = engine.scan_text(sample, "f.py", 3.5, True)
     ids = {f.rule_id for f in findings}
     assert rule_id in ids, f"{rule_id} not found in {ids}"
+
+
+def test_service_tokens_require_provider_keyword():
+    findings = engine.scan_text("token = 'key-" + ("a1b2" * 8) + "'", "f.py", 3.5, True)
+    assert all(
+        f.rule_id not in {"mailgun-api-token", "postmark-api-token"}
+        for f in findings
+    )
 
 
 def test_private_key_block_detected():


### PR DESCRIPTION
## Summary
- Add two new secret rules in `skills/secret-scanner/engine.py`:
  - `mailgun-api-token`
  - `postmark-api-token`
- Add regression tests in `skills/secret-scanner/tests/test_engine.py`:
  - true positives for `mailgun_token` and `postmark_server_key` strings
  - negative test ensuring a raw `key-...` without vendor keyword does not match these new rules

## Issue
Closes #2

## Validation
- Created an isolated venv and installed pytest for local validation
- `.venv/bin/python -m pytest skills/secret-scanner/tests/test_engine.py -q` => `27 passed`

## Notes on project check
This repo is Python-only and no root `npm run check` workflow is defined; I validated the change with the targeted scanner test module.
